### PR TITLE
Adds support for changing spark worker properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The following platforms are not tested but will probably work (tests coming soon
   Spark standalone executors. A free port is chosen if this port is unavailable.
 * `node['apache_spark']['standalone']['common_extra_classpath_items']`: common classpath items to
   add to Spark application driver and executors (but not Spark master and worker processes).
+* `node['apache_spark']['standalone']['worker_dir']`: Set to a non-nil value to tell the spark worker to use an alternate directory for spark scratch space
+* `node['apache_spark']['standalone']['worker_opts']`: Set to a non-nil value to pass along any additional settings to the spark worker. E.G.: `-Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.appDataTtl=86400`.  Ideal for worker options only that you do not want in the default configuration file.
 * `node['apache_spark']['conf']['...']`: Spark configuration options that go into the default
   Spark configuration file. See https://spark.apache.org/docs/latest/configuration.html for details.
 * `node['apache_spark']['standalone']['local_dirs']`: a list of local directories to use on workers.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,6 +75,14 @@ default['apache_spark']['standalone']['executor_debug_port'] = '23030'
 # Extra classpath items for both driver and executor processes of Spark apps.
 default['apache_spark']['standalone']['common_extra_classpath_items'] = []
 
+# By default, spark will use `SPARK_HOME/work` for scratch space. 
+# We can adjust `SPARK_WORKER_DIR` if we set this to a non nil value
+default['apache_spark']['standalone']['worker_dir'] = nil
+
+# Anything you'd like passed along, from https://spark.apache.org/docs/latest/spark-standalone.html#cluster-launch-scripts
+# E.G.: " -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.appDataTtl=86400"
+default['apache_spark']['standalone']['worker_opts'] = nil
+
 # Default configuration options for Spark.
 default['apache_spark']['conf']['spark.akka.frameSize'] = 100
 

--- a/templates/default/spark-env.sh.erb
+++ b/templates/default/spark-env.sh.erb
@@ -40,11 +40,13 @@ export SPARK_MASTER_PORT=<%= @master_port %>
 export SPARK_MASTER_WEBUI_PORT=<%= @master_webui_port %>
 
 
-export SPARK_WORKER_OPTS
-<% if @worker_cores  %>
-export SPARK_WORKER_CORES=<%= @worker_cores %>
+<% if @worker_opts  %>
+export SPARK_WORKER_OPTS+=<%= @worker_opts %>
 <% end %>
-export SPARK_WORKER_DIR+=" -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.appDataTtl=86400"
+
+<% if @worker_dir  %>
+export SPARK_WORKER_DIR=<%= @worker_dir %>
+<% end %>
 
 export SPARK_WORKER_MEMORY="<%= @worker_memory_mb %>m"
 export SPARK_WORKER_WEBUI_PORT=<%= @worker_webui_port %>

--- a/templates/default/spark-env.sh.erb
+++ b/templates/default/spark-env.sh.erb
@@ -39,6 +39,13 @@ export SPARK_MASTER_IP=<%= @master_bind_ip %>
 export SPARK_MASTER_PORT=<%= @master_port %>
 export SPARK_MASTER_WEBUI_PORT=<%= @master_webui_port %>
 
+
+export SPARK_WORKER_OPTS
+<% if @worker_cores  %>
+export SPARK_WORKER_CORES=<%= @worker_cores %>
+<% end %>
+export SPARK_WORKER_DIR+=" -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.appDataTtl=86400"
+
 export SPARK_WORKER_MEMORY="<%= @worker_memory_mb %>m"
 export SPARK_WORKER_WEBUI_PORT=<%= @worker_webui_port %>
 <% if @worker_cores  %>


### PR DESCRIPTION
Specifically, the worker's scratch directory and any additional worker only options.

Cookbook version number **not** increased until merge request is OK'd as this is a task for the cookbook maintainer (but i can do, if needed, to make the merge really easy)