### PR TITLE
Replaces hardcoded `spark` username with attribute

### DIFF
--- a/recipes/spark-standalone-worker.rb
+++ b/recipes/spark-standalone-worker.rb
@@ -26,6 +26,7 @@ template worker_runner_script do
   owner spark_user
   group spark_group
   variables node['apache_spark']['standalone'].merge(
+    spark_user: spark_user,
     install_dir: node['apache_spark']['install_dir']
   )
 end

--- a/templates/default/spark_worker_runner.sh.erb
+++ b/templates/default/spark_worker_runner.sh.erb
@@ -19,7 +19,7 @@ ulimit -n <%= @max_num_open_files %>
 export SPARK_DAEMON_JAVA_OPTS="-Dspark.root.logger=<%= @daemon_root_logger %> \
                                -Dspark.log.file=spark-standalone-worker.log"
 
-exec sudo -u spark <%= @install_dir %>/bin/spark-class \
+exec sudo -u <%= @spark_user %> <%= @install_dir %>/bin/spark-class \
     org.apache.spark.deploy.worker.Worker \
     --ip <%= @worker_bind_ip %> \
     --webui-port <%= @worker_webui_port %> \


### PR DESCRIPTION
Current `worker_runner.sh` fails if spark is being run under a different username.

This patch fixes that by using the supplied user attribute.