### PR TITLE
spark standalone master monit cmd line pattern fixed

### DIFF
--- a/recipes/spark-standalone-master.rb
+++ b/recipes/spark-standalone-master.rb
@@ -36,7 +36,7 @@ monit_wrapper_monitor service_name do
   template_source 'pattern-based_service.conf.erb'
   template_cookbook 'monit_wrapper'
   variables \
-    cmd_line_pattern: '^java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
+    cmd_line_pattern: 'java.* org\.apache\.spark\.deploy\.master\.Master ',
     cmd_line: master_runner_script,
     user: spark_user,
     group: spark_group


### PR DESCRIPTION
I tried using this cookbook on ubuntu 14.04 - monit was unable to identify running spark master process and the cookbook kept failing for timeout on waiting for spark-standalone-master. After fixing the cmd line pattern it started working.