### PR TITLE
allow monit process matcher to be configured by node object

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: centos-6.5
     driver_config:
       box: opscode-centos-6.5

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 driver:
-  name: vagrant
+  name: <%= ENV['KI_DRIVER'] || 'vagrant' %>
   customize:
     cpus: 2
     memory: 2048

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,16 +7,16 @@ AllCops:
     - Guardfile
   Exclude:
     - vendor/**/*
-    - cookbooks/**/*
-
-LineLength:
-  Enabled: false
 
 Documentation:
   Enabled: false
-
 FileName:
   Enabled: false
-
-Next:
+SignalException:
+  Enabled: false
+Encoding:
+  Enabled: false
+HashSyntax:
+  Enabled: false
+LineLength:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@
 desc 'Install berkshelf cookbooks locally'
 task :berkshelf do
   system('berks install')
+  system('berks update')
 end
 
 # Style tests. Rubocop and Foodcritic
@@ -14,11 +15,13 @@ namespace :style do
     require 'foodcritic'
 
     desc 'Run Chef style checks'
-    puts 'Running Foodcritic...'
-    FoodCritic::Rake::LintTask.new(:chef) do |t|
-      t.options = {
-        fail_tags: ['any']
-      }
+    task :foodcritic do
+      FoodCritic::Rake::LintTask.new(:chef) do |t|
+        puts 'Running Foodcritic...'
+        t.options = {
+          fail_tags: ['any']
+        }
+      end
     end
   rescue LoadError
     puts '>>>>> foodcritic gem not loaded, omitting tasks' unless ENV['CI']
@@ -33,9 +36,6 @@ namespace :style do
   end
 end
 
-desc 'Run all style checks'
-task style: ['style:chef', 'style:ruby']
-
 namespace :unit do
   begin
     require 'rspec/core/rake_task'
@@ -46,24 +46,90 @@ namespace :unit do
   end
 end
 
-desc 'Run all unit tests'
-task unit: ['unit:rspec']
-
 # Integration tests. Kitchen.ci
 namespace :integration do
   begin
-    require 'kitchen/rake_tasks'
-
-    desc 'Run kitchen integration tests'
-    Kitchen::RakeTasks.new
+    desc 'Run integration tests with kitchen-vagrant'
+    task :vagrant do
+      require 'kitchen'
+      Kitchen.logger = Kitchen.default_file_logger
+      Kitchen::Config.new.instances.each do |instance|
+        instance.test(:always)
+      end
+    end
   rescue LoadError
-    puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+    puts '>>>>> kitchen gem not loaded, omitting tasks' unless ENV['CI']
+  end
+
+  begin
+    desc 'Run integration tests with kitchen-docker'
+    task :docker do
+      ENV['KI_DRIVER'] = 'docker'
+      require 'kitchen'
+      Kitchen.logger = Kitchen.default_file_logger
+      Kitchen::Config.new.instances.each do |instance|
+        instance.test(:always)
+      end
+    end
+  rescue LoadError
+    puts '>>>>> kitchen gem not loaded, omitting tasks' unless ENV['CI']
   end
 end
 
-desc 'Run all tests on Travis'
-task travis: %w(style unit)
+desc 'Run Test Kitchen integration tests'
+task 'integration:vagrant'
 
-# Default
-# task default: ['unit', 'style', 'integration:kitchen:all']
-task default: ['unit', 'style', 'integration:kitchen:all']
+desc 'Run all style checks'
+task style: ['style:foodcritic', 'style:ruby']
+
+desc 'Run all unit tests'
+task unit: ['unit:rspec']
+
+desc 'Run style and unit tests for light CI'
+task travis: %w(berkshelf style unit)
+
+desc 'Run all tests including test Kitchen with Vagrant'
+task default: ['unit', 'style', 'integration:vagrant']
+
+desc 'Run all tests including test Kitchen with Docker'
+task docker: ['unit', 'style', 'integration:docker']
+
+desc 'print cookbook version'
+task :version do
+  puts cookbook_version
+end
+
+desc 'bump minor version'
+task :bump do
+  versions = cookbook_version.split('.')
+  versions[2] = versions[2].to_i + 1
+  version = versions.join('.')
+  puts "bumping cookbook version to #{version}"
+
+  update_cookbook_version version
+
+  # run_command "git commit metadata.rb -m 'version bumped to #{version}'"
+end
+
+VERSION_WITH_NAME_REGEX = /version\s*'\d+\.\d+\.\d+'/
+VERSION_REGEX = /\d+\.\d+\.\d+/
+
+def cookbook_version
+  # Read in the metadata file
+  metadata = IO.read(File.join(File.dirname(__FILE__), 'metadata.rb')).chomp
+  version_with_name = VERSION_WITH_NAME_REGEX.match(metadata)[0]
+  VERSION_REGEX.match(version_with_name)[0]
+end
+
+def update_cookbook_version(version)
+  # Read in the metadata file
+  metadata = File.read('metadata.rb')
+  new_metadata = metadata.gsub(/#{VERSION_WITH_NAME_REGEX}/, "version '#{version}'")
+  File.open('metadata.rb', 'w') { |file| file.puts new_metadata }
+  puts
+end
+
+def run_command(command)
+  output = `#{command}`
+  raise "#{command} failed with:\n#{output}" unless $CHILD_STATUS.success?
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,3 +91,8 @@ default['apache_spark']['conf']['spark.deploy.spreadOut'] = true
 default['apache_spark']['conf']['spark.executor.extraLibraryPath'] = '/usr/lib/hadoop/lib/native'
 
 default['apache_spark']['standalone']['local_dirs'] = ['/var/local/spark']
+
+default['apache_spark']['standalone_master']['monit']['process_matcher'] =
+  '^java.* (org\\.apache\\.)?spark\\.deploy\\.master\\.Master '
+default['apache_spark']['standalone_worker']['monit']['process_matcher'] =
+  'java.* org\.apache\.spark\.deploy\.worker\.Worker '

--- a/recipes/spark-install.rb
+++ b/recipes/spark-install.rb
@@ -71,7 +71,7 @@ local_dirs = node['apache_spark']['standalone']['local_dirs']
     spark_conf_dir,
     node['apache_spark']['standalone']['log_dir'],
     node['apache_spark']['standalone']['worker_work_dir']
-  ] + local_dirs
+  ] + local_dirs.to_a
 ).each do |dir|
   directory dir do
     mode 0755

--- a/recipes/spark-standalone-master.rb
+++ b/recipes/spark-standalone-master.rb
@@ -16,6 +16,8 @@ include_recipe 'apache_spark::spark-install'
 include_recipe 'monit_wrapper'
 
 master_runner_script = ::File.join(node['apache_spark']['install_dir'], 'bin', 'master_runner.sh')
+master_process_matcher = node['apache_spark']['standalone_master']['monit']['process_matcher']
+master_service_name = 'spark-standalone-master'
 
 spark_user = node['apache_spark']['user']
 spark_group = node['apache_spark']['group']
@@ -31,18 +33,17 @@ template master_runner_script do
 end
 
 # Run Spark standalone master with Monit
-service_name = 'spark-standalone-master'
-monit_wrapper_monitor service_name do
+monit_wrapper_monitor master_service_name do
   template_source 'pattern-based_service.conf.erb'
   template_cookbook 'monit_wrapper'
   variables \
-    cmd_line_pattern: '^java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
+    cmd_line_pattern: master_process_matcher,
     cmd_line: master_runner_script,
     user: spark_user,
     group: spark_group
 end
 
-monit_wrapper_service service_name do
+monit_wrapper_service master_service_name do
   action :start
 
   # Determine the "notification action" based on whether the service is running at recipe compile
@@ -50,9 +51,9 @@ monit_wrapper_service service_name do
   # start as part of the :start action and pick up the new software version and configuration
   # anyway, so we don't have to restart it as part of delayed notification.
   # TODO: put this logic in a library method in monit_wrapper.
-  notification_action = monit_service_exists_and_running?(service_name) ? :restart : :start
+  notification_action = monit_service_exists_and_running?(master_service_name) ? :restart : :start
 
-  subscribes notification_action, "monit-wrapper_monitor[#{service_name}]", :delayed
+  subscribes notification_action, "monit-wrapper_monitor[#{master_service_name}]", :delayed
   subscribes notification_action, "package[#{node['apache_spark']['pkg_name']}]", :delayed
   subscribes notification_action, "template[#{master_runner_script}]", :delayed
 end

--- a/recipes/spark-standalone-worker.rb
+++ b/recipes/spark-standalone-worker.rb
@@ -16,6 +16,8 @@ include_recipe 'apache_spark::spark-install'
 include_recipe 'monit_wrapper'
 
 worker_runner_script = ::File.join(node['apache_spark']['install_dir'], 'worker_runner.sh')
+worker_process_matcher = node['apache_spark']['standalone_worker']['monit']['process_matcher']
+worker_service_name = 'spark-standalone-worker'
 
 spark_user = node['apache_spark']['user']
 spark_group = node['apache_spark']['group']
@@ -68,25 +70,24 @@ logrotate_app 'worker-dir-cleanup-log' do
 end
 
 # Run Spark standalone worker with Monit
-service_name = 'spark-standalone-worker'
 master_host_port = format(
   '%s:%d',
   node['apache_spark']['standalone']['master_host'],
   node['apache_spark']['standalone']['master_port'].to_i
 )
 
-monit_wrapper_monitor service_name do
+monit_wrapper_monitor worker_service_name do
   template_source 'pattern-based_service.conf.erb'
   template_cookbook 'monit_wrapper'
   wait_for_host_port master_host_port
   variables \
-    cmd_line_pattern: 'java.* org\.apache\.spark\.deploy\.worker\.Worker ',
+    cmd_line_pattern: worker_process_matcher,
     cmd_line: worker_runner_script,
     user: 'root',  # The worker needs to run as root initially to use ulimit.
     group: 'root'
 end
 
-monit_wrapper_service service_name do
+monit_wrapper_service worker_service_name do
   action :start
   wait_for_host_port master_host_port
 
@@ -95,9 +96,9 @@ monit_wrapper_service service_name do
   # start as part of the :start action and pick up the new software version and configuration
   # anyway, so we don't have to restart it as part of delayed notification.
   # TODO: put this logic in a library method in monit_wrapper.
-  notification_action = monit_service_exists_and_running?(service_name) ? :restart : :start
+  notification_action = monit_service_exists_and_running?(worker_service_name) ? :restart : :start
 
-  subscribes notification_action, "monit-wrapper_monitor[#{service_name}]", :delayed
+  subscribes notification_action, "monit-wrapper_monitor[#{worker_service_name}]", :delayed
   subscribes notification_action, "package[#{node['apache_spark']['pkg_name']}]", :delayed
   subscribes notification_action, "template[#{worker_runner_script}]", :delayed
 end


### PR DESCRIPTION
While testing an upgrade to spark 1.4.1 I found monit wouldn't match the process and started about 10 instances of spark master.  It turned out to be the new install used a full path to java /usr/something/somthing/bin/java rather than just java to start the spark master and the cookbook matching pattern was based on '^java...'  This pull request moves that regex to a node attribute so it can be overwritten by a wrapper cookbook.