### PR TITLE
remove the start of line anchor from regex monit uses to test master is running

### DIFF
--- a/recipes/spark-standalone-master.rb
+++ b/recipes/spark-standalone-master.rb
@@ -36,7 +36,7 @@ monit_wrapper_monitor service_name do
   template_source 'pattern-based_service.conf.erb'
   template_cookbook 'monit_wrapper'
   variables \
-    cmd_line_pattern: '^java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
+    cmd_line_pattern: 'java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
     cmd_line: master_runner_script,
     user: spark_user,
     group: spark_group


### PR DESCRIPTION
was getting tripped up by the full path to java being in the cmdline for spark master

this matches what is already done in the worker recipe, which doesn't use an anchor to the start of the line.

