### PR TITLE
Feature fix worker ip

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default['apache_spark']['standalone']['master_host'] = 'localhost'
 default['apache_spark']['standalone']['master_port'] = 7077
 default['apache_spark']['standalone']['master_webui_port'] = '18080'
 
-default['apache_spark']['standalone']['worker_bind_ip'] = '0.0.0.0'
+default['apache_spark']['standalone']['worker_bind_ip'] = nil
 default['apache_spark']['standalone']['worker_webui_port'] = 8081
 
 default['apache_spark']['standalone']['job_dir_days_retained'] = 7

--- a/recipes/spark-standalone-master.rb
+++ b/recipes/spark-standalone-master.rb
@@ -36,7 +36,7 @@ monit_wrapper_monitor service_name do
   template_source 'pattern-based_service.conf.erb'
   template_cookbook 'monit_wrapper'
   variables \
-    cmd_line_pattern: '^java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
+    cmd_line_pattern: 'java.* (org\.apache\.)?spark\.deploy\.master\.Master ',
     cmd_line: master_runner_script,
     user: spark_user,
     group: spark_group

--- a/templates/default/spark_worker_runner.sh.erb
+++ b/templates/default/spark_worker_runner.sh.erb
@@ -21,7 +21,9 @@ export SPARK_DAEMON_JAVA_OPTS="-Dspark.root.logger=<%= @daemon_root_logger %> \
 
 exec sudo -u <%= @user %> <%= @install_dir %>/bin/spark-class \
     org.apache.spark.deploy.worker.Worker \
+<% if @worker_bind_ip %>
     --ip <%= @worker_bind_ip %> \
+<% end %>
     --webui-port <%= @worker_webui_port %> \
     --work-dir <%= @worker_work_dir %> \
     --memory <%= @worker_memory_mb %>m \


### PR DESCRIPTION
Two small fixes, the first, ensures the spark process can be found by correcting the regex used to look for the process (previously did not account for a path name to the java process). This matches the current regex pattern used for the master.

The second fix is around worker_bind_ip, which is now made optional, and will not be passed if not set. I found I needed to do this when working on an autoscale configuration, and baking an AMI with the worker pre-configured.