### PR TITLE
Fix the kill command for spark worker

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,4 +115,4 @@ default['apache_spark']['standalone']['local_dirs'] = ['/var/local/spark']
 default['apache_spark']['standalone']['master_cmdline_pattern'] =
   '^(/\S+/)?java .* org[.]apache[.]spark[.]deploy[.]master[.]Master '
 default['apache_spark']['standalone']['worker_cmdline_pattern'] =
-  '^(/\S+/)?java .* org[.]apache[.]spark[.]deploy[.]worker[.]Worker '
+  '.*spark-class .* org[.]apache[.]spark[.]deploy[.]worker[.]Worker '

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ maintainer 'ClearStory Data, Inc.'
 maintainer_email 'mbautin@clearstorydata.com'
 license 'Apache License 2.0'
 description 'A cookbook to install and configure Apache Spark'
-version '1.2.14'
+version '1.2.15'
 source_url 'https://github.com/clearstorydata-cookbooks/apache_spark'
 issues_url 'https://github.com/clearstorydata-cookbooks/apache_spark/issues'
 


### PR DESCRIPTION
The worker process cannot be killed as it is not found by pkill, as
pkill is looking for the process owned by root user. Whereas the actual process is running as root. 
So kill the parent process instead which runs as root, but it uses the spark-class script. So the regex needs to be adjusted:
https://github.com/clearstorydata-cookbooks/apache_spark/issues/15