### PR TITLE
Update logrotate version lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
 source 'https://rubygems.org'
 
-gem 'chef', '>= 11.18.6'
 gem 'berkshelf', '~> 4.0'
 gem 'berkshelf-api-client', '~> 2.0'
+gem 'chef', '>= 11.18.6'
 gem 'stove', '~> 3.2'
 
 group :test do
   gem 'chefspec', '~> 4.2'
-  gem 'rspec', '~> 3.2'
   gem 'foodcritic', '~> 4.0'
+  gem 'rspec', '~> 3.2'
   gem 'rubocop', '~> 0.27.1'
 end
 
 group :integration do
-  gem 'test-kitchen', '~> 1.4'
-  gem 'kitchen-vagrant'
-  gem 'kitchen-sync'
   gem 'kitchen-ec2', '~> 0.10'
+  gem 'kitchen-sync'
+  gem 'kitchen-vagrant'
+  gem 'test-kitchen', '~> 1.4'
 end
 
 group :documentation do

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,10 +18,9 @@ maintainer_email 'mbautin@clearstorydata.com'
 license 'Apache License 2.0'
 description 'A cookbook to install and configure Apache Spark'
 version '1.2.14'
-source_url 'https://github.com/clearstorydata-cookbooks/apache_spark'
-issues_url 'https://github.com/clearstorydata-cookbooks/apache_spark/issues'
+chef_version '>= 11.18.6'
 
-%w( debian ubuntu centos redhat fedora ).each do |os|
+%w(debian ubuntu centos redhat fedora).each do |os|
   supports os
 end
 
@@ -30,3 +29,6 @@ depends 'java'
 depends 'logrotate'
 depends 'monit_wrapper'
 depends 'tar'
+
+source_url 'https://github.com/clearstorydata-cookbooks/apache_spark'
+issues_url 'https://github.com/clearstorydata-cookbooks/apache_spark/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,6 +27,6 @@ end
 
 depends 'apt', '~> 2.0'
 depends 'java', '~> 1.0'
-depends 'logrotate', '~> 1.0'
+depends 'logrotate', '~> 2.1'
 depends 'monit_wrapper', '~> 3.0'
 depends 'tar'

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,8 +25,8 @@ issues_url 'https://github.com/clearstorydata-cookbooks/apache_spark/issues'
   supports os
 end
 
-depends 'apt', '~> 2.0'
-depends 'java', '~> 1.0'
-depends 'logrotate', '~> 2.1'
-depends 'monit_wrapper', '~> 3.0'
+depends 'apt'
+depends 'java'
+depends 'logrotate'
+depends 'monit_wrapper'
 depends 'tar'

--- a/recipes/find-free-port.rb
+++ b/recipes/find-free-port.rb
@@ -14,7 +14,7 @@
 
 template '/usr/local/bin/find-free-port.rb' do
   source 'find-free-port.rb.erb'
-  mode 0755
+  mode '0755'
   owner 'root'
   group 'root'
   variables ruby_interpreter: RbConfig.ruby

--- a/recipes/spark-install.rb
+++ b/recipes/spark-install.rb
@@ -74,7 +74,7 @@ local_dirs = node['apache_spark']['standalone']['local_dirs']
   ] + local_dirs.to_a
 ).each do |dir|
   directory dir do
-    mode 0755
+    mode '0755'
     owner spark_user
     group spark_group
     action :create
@@ -84,7 +84,7 @@ end
 
 template "#{spark_conf_dir}/spark-env.sh" do
   source 'spark-env.sh.erb'
-  mode 0644
+  mode '0644'
   owner spark_user
   group spark_group
   variables node['apache_spark']['standalone']
@@ -97,7 +97,7 @@ end
 
 template "#{spark_conf_dir}/log4j.properties" do
   source 'spark_log4j.properties.erb'
-  mode 0644
+  mode '0644'
   owner spark_user
   group spark_group
   variables node['apache_spark']['standalone']
@@ -110,7 +110,7 @@ default_executor_mem_mb = node['apache_spark']['standalone']['default_executor_m
 
 template "#{spark_conf_dir}/spark-defaults.conf" do
   source 'spark-defaults.conf.erb'
-  mode 0644
+  mode '0644'
   owner spark_user
   group spark_group
   variables options: node['apache_spark']['conf'].to_hash.merge(

--- a/recipes/spark-standalone-master.rb
+++ b/recipes/spark-standalone-master.rb
@@ -23,7 +23,7 @@ spark_group = node['apache_spark']['group']
 
 template master_runner_script do
   source 'spark_master_runner.sh.erb'
-  mode 0744
+  mode '0744'
   owner spark_user
   group spark_group
   variables node['apache_spark']['standalone'].merge(

--- a/recipes/spark-standalone-worker.rb
+++ b/recipes/spark-standalone-worker.rb
@@ -29,7 +29,7 @@ end
 
 template worker_runner_script do
   source 'spark_worker_runner.sh.erb'
-  mode 0744
+  mode '0744'
   owner spark_user
   group spark_group
   variables node['apache_spark']['standalone'].merge(
@@ -40,7 +40,7 @@ template worker_runner_script do
 end
 
 directory node['apache_spark']['standalone']['worker_work_dir'] do
-  mode 0755
+  mode '0755'
   owner spark_user
   group spark_group
   action :create
@@ -49,7 +49,7 @@ end
 
 template '/usr/local/bin/clean_spark_worker_dir.rb' do
   source 'clean_spark_worker_dir.rb.erb'
-  mode 0755
+  mode '0755'
   owner 'root'
   group 'root'
   variables ruby_interpreter: RbConfig.ruby

--- a/spec/spark-standalone-master_spec.rb
+++ b/spec/spark-standalone-master_spec.rb
@@ -7,7 +7,7 @@ describe 'apache_spark::spark-standalone-master' do
     it 'adds the master runner script' do
       expect(chef_run).to create_template('/usr/share/spark/bin/master_runner.sh').with(
         source: 'spark_master_runner.sh.erb',
-        mode: 0744,
+        mode: '0744',
         owner: 'spark',
         group: 'spark'
       )

--- a/test/cookbooks/apache_spark_test/files/default/tests/minitest/spark_test.rb
+++ b/test/cookbooks/apache_spark_test/files/default/tests/minitest/spark_test.rb
@@ -26,20 +26,32 @@ describe_recipe 'apache_spark::spark-install' do
     stop_spark
 
     start_monit_service('spark-standalone-master')
-    assert_equal('Running', get_stable_monit_service_status('spark-standalone-master'))
+    assert_equal(
+      'Running',
+      get_stable_monit_service_status('spark-standalone-master')
+    )
 
     # The worker should still be down.
-    assert_equal('Not monitored', get_stable_monit_service_status('spark-standalone-worker'))
+    assert_equal(
+      'Not monitored',
+      get_stable_monit_service_status('spark-standalone-worker')
+    )
   end
 
   it 'allows starting Spark standalone worker' do
     stop_spark
 
     start_monit_service('spark-standalone-worker')
-    assert_equal('Running', get_stable_monit_service_status('spark-standalone-worker'))
+    assert_equal(
+      'Running',
+      get_stable_monit_service_status('spark-standalone-worker')
+    )
 
     # The master should still be down.
-    assert_equal('Not monitored', get_stable_monit_service_status('spark-standalone-master'))
+    assert_equal(
+      'Not monitored',
+      get_stable_monit_service_status('spark-standalone-master')
+    )
   end
 
   it 'allows to run a Spark program (SparkPi)' do
@@ -63,6 +75,7 @@ describe_recipe 'apache_spark::spark-install' do
     assert(
       spark_pi_result.stdout.include?(expected_msg),
       "Expected stdout to say '#{expected_msg}'. " \
-      "Actual stdout:\n#{spark_pi_result.stdout}\n\nStderr:\n#{spark_pi_result.stderr}")
+      "Actual stdout:\n#{spark_pi_result.stdout}\n\nStderr:\n#{spark_pi_result.stderr}"
+    )
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -16,17 +16,17 @@ describe 'apache_spark' do
   end
 
   # Spark master port
-  describe port(7077) do
+  describe port(7_077) do
     it { should be_listening }
   end
 
   # Spark master WebUI port
-  describe port('8081') do
+  describe port(8_081) do
     it { should be_listening }
   end
 
   # Spark worker WebUI port
-  describe port('18080') do
+  describe port(18_080) do
     it { should be_listening }
   end
 


### PR DESCRIPTION
As per the [Issue #23 ](https://github.com/clearstorydata-cookbooks/apache_spark/issues/23) the cookbook works fine with logrotate 2.1. This PR updates the metadata lock for latest working logrotate version.